### PR TITLE
Solves possible out of bound for Graph object(s)

### DIFF
--- a/Graph.cpp
+++ b/Graph.cpp
@@ -89,7 +89,7 @@ namespace supbub {
 
   void 
   Graph::addEdge(int64_t u, int64_t v){
-    if (u > _numVertices || u > _numVertices || u < 0 || v < 0) {
+    if (u > _numVertices || v > _numVertices || u < 0 || v < 0) {
       log("Invalid u or v : ", u, v);
     }
     _adjList[u].push_back(v);


### PR DESCRIPTION
Dear vgteam,

I found a redundant comparison (comparing `u > _numVertices` twice) while I think this should check v for being out of bound. I hope the fix is correct and of any use to you.

all best,

Youri
